### PR TITLE
fix bug under node > 4.0.0

### DIFF
--- a/lib/bundler/js.js
+++ b/lib/bundler/js.js
@@ -59,7 +59,9 @@ module.exports = function(pkg, digdeps, built_root, options, callback) {
         var rs = {};
 
         mainFiles.forEach(function(file, idx) {
-          var streams = files.concat(absFiles[idx]).map(fs.createReadStream);
+          var streams = files.concat(absFiles[idx]).map(function (f) {
+            return fs.createReadStream(f);
+          });
 
           var pre, suf;
           if (prefix) {


### PR DESCRIPTION
`Array.prototype.map` provides 3 arguments (`currentValue`, `index(number)`, `array`).
`fs.createReadStream` accepts 2 arguments (`path(string)`, `options(object)`).
The second value `index`, which is a _number_, is treated as `options` by `createReadStream`, and that caused an error with node > 4.0.0.
